### PR TITLE
Fix issue with session validation when lifetime is set to 0

### DIFF
--- a/app/code/local/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/local/Mage/Core/Model/Session/Abstract/Varien.php
@@ -385,7 +385,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
      */
     public function useValidateSessionExpire()
     {
-        return true;
+        return $this->getCookie()->getLifetime() > 0;
     }
 
     /**


### PR DESCRIPTION
There is a problem when you have set session life-time being equal to the life-time of the browser session. In this case validation always returns false and all the website is broken :(